### PR TITLE
246

### DIFF
--- a/backend/src/features/validationServices/errorStructuring.ts
+++ b/backend/src/features/validationServices/errorStructuring.ts
@@ -187,7 +187,6 @@ export function structureError(message: string): FeedbackError {
 
   // Pattern: "Missing variable: function \"name\" expected \"var\""
   const missingVarFuncMatch = message.match(/Missing variable: function "(.+?)" expected "(.+?)"/i);
-
   if (missingVarFuncMatch) {
     return {
       type: ErrorType.MISSING_ELEMENT,

--- a/backend/src/features/validationServices/errorStructuring.ts
+++ b/backend/src/features/validationServices/errorStructuring.ts
@@ -187,7 +187,7 @@ export function structureError(message: string): FeedbackError {
 
   // Pattern: "Missing variable: function \"name\" expected \"var\""
   const missingVarFuncMatch = message.match(/Missing variable: function "(.+?)" expected "(.+?)"/i);
-  
+
   if (missingVarFuncMatch) {
     return {
       type: ErrorType.MISSING_ELEMENT,

--- a/backend/src/features/validationServices/errorStructuring.ts
+++ b/backend/src/features/validationServices/errorStructuring.ts
@@ -185,13 +185,16 @@ export function structureError(message: string): FeedbackError {
     };
   }
 
+  // Pattern: "Function \"name\" is missing a variable expected \"var\""
   // Pattern: "Missing variable: function \"name\" expected \"var\""
-  const missingVarFuncMatch = message.match(/Missing variable: function "(.+?)" expected "(.+?)"/i);
+  const missingVarFuncMatch = message.match(/Function "(.+?)" is missing a variable expected "(.+?)"/i);
+  // const missingVarFuncMatch = message.match(/Missing variable: function "(.+?)" expected "(.+?)"/i);
+  
   if (missingVarFuncMatch) {
     return {
       type: ErrorType.MISSING_ELEMENT,
       message,
-      path: `${missingVarFuncMatch[1]}.${missingVarFuncMatch[2]}`,
+      path: `${missingVarFuncMatch[1]}.${missingVarFuncMatch[2]}`, // TODO might need to adjust with new message
       severity: 'error',
     };
   }

--- a/backend/src/features/validationServices/errorStructuring.ts
+++ b/backend/src/features/validationServices/errorStructuring.ts
@@ -185,16 +185,14 @@ export function structureError(message: string): FeedbackError {
     };
   }
 
-  // Pattern: "Function \"name\" is missing a variable expected \"var\""
   // Pattern: "Missing variable: function \"name\" expected \"var\""
-  const missingVarFuncMatch = message.match(/Function "(.+?)" is missing a variable expected "(.+?)"/i);
-  // const missingVarFuncMatch = message.match(/Missing variable: function "(.+?)" expected "(.+?)"/i);
+  const missingVarFuncMatch = message.match(/Missing variable: function "(.+?)" expected "(.+?)"/i);
   
   if (missingVarFuncMatch) {
     return {
       type: ErrorType.MISSING_ELEMENT,
       message,
-      path: `${missingVarFuncMatch[1]}.${missingVarFuncMatch[2]}`, // TODO might need to adjust with new message
+      path: `${missingVarFuncMatch[1]}.${missingVarFuncMatch[2]}`,
       severity: 'error',
     };
   }

--- a/backend/src/features/validationServices/validateAnswer.ts
+++ b/backend/src/features/validationServices/validateAnswer.ts
@@ -268,8 +268,7 @@ function checkSet(
   for (const extraId of unmatched)
     errors.push({
       type: ErrorType.UNEXPECTED_ELEMENT,
-      message: `The set with id4 TODO has an unexpected element id=${extraId}`,//TODO
-      // message: `Unexpected element: ${path} id=${extraId}`,
+      message: `Unexpected element: ${path} id=${extraId}`,
       elementId: inputMemoryBox.id ?? undefined, // The container with unexpected elements
       path,
       severity: 'error'
@@ -610,7 +609,8 @@ function compareIds(
     // if either ID is not found in the respective map
     errors.push({
       type: ErrorType.ORPHANED_ELEMENT,
-      message: `Unmapped ID: ${path}`,
+      // Remove → from end of path (if it is there)
+      message: `Unmapped ID: ${path.endsWith('→') ? path.slice(0, -1) : path}`,
       path,
       severity: 'error'
     });

--- a/backend/src/features/validationServices/validateAnswer.ts
+++ b/backend/src/features/validationServices/validateAnswer.ts
@@ -268,7 +268,8 @@ function checkSet(
   for (const extraId of unmatched)
     errors.push({
       type: ErrorType.UNEXPECTED_ELEMENT,
-      message: `Unexpected element: ${path} id=${extraId}`,
+      message: `The set with id4 TODO has an unexpected element id=${extraId}`,//TODO
+      // message: `Unexpected element: ${path} id=${extraId}`,
       elementId: inputMemoryBox.id ?? undefined, // The container with unexpected elements
       path,
       severity: 'error'
@@ -489,7 +490,8 @@ function compareFrames(
       if (!(k in uVars))
         errors.push({
           type: ErrorType.MISSING_ELEMENT,
-          message: `Missing variable: function "${name}" expected "${k}"`,
+          message: `Function "${name}" is missing a variable expected "${k}"`,
+          // message: `Missing variable: function "${name}" expected "${k}"`,
           elementId: uFrame.id ?? undefined,
           path: `function "${name}" → var "${k}"`,
           severity: 'error'

--- a/backend/src/features/validationServices/validateAnswer.ts
+++ b/backend/src/features/validationServices/validateAnswer.ts
@@ -489,8 +489,7 @@ function compareFrames(
       if (!(k in uVars))
         errors.push({
           type: ErrorType.MISSING_ELEMENT,
-          message: `Function "${name}" is missing a variable expected "${k}"`,
-          // message: `Missing variable: function "${name}" expected "${k}"`,
+          message: `Missing variable: function "${name}" expected "${k}"`,
           elementId: uFrame.id ?? undefined,
           path: `function "${name}" → var "${k}"`,
           severity: 'error'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
   "contributors": [
     "Kevin Chen",
     "Lily Meng",
-    "Aditya Shankar Sarma Peri"
+    "Aditya Shankar Sarma Peri",
+    "Xi (James) Chen"
   ]
 }

--- a/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
+++ b/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
@@ -91,7 +91,7 @@ export default function ErrorListDisplay({
     let displayMessage = processErrorMessage(message, isSandboxMode);
     let errorType = "";
 
-    if (message.includes("missing a variable")) {
+    if (message.includes("Missing variable")) {
       errorType = "Missing variable";
     } else if (message.includes("Unexpected variable")) {
       errorType = "Unexpected variable";

--- a/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
+++ b/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
@@ -72,7 +72,7 @@ export default function ErrorListDisplay({
 
     let processed = message;
 
-    // Do not trim messages that have "unexpected" in it
+    // Do not edit messages that have "unexpected" in it
     if (!message.toLowerCase().includes("unexpected")) {
       processed = processed.replace(/expected\s+[^,]+,\s+got\s+/gi, "got ");
       processed = processed.replace(/,?\s*expected\s+[^,]+$/gi, "");

--- a/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
+++ b/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
@@ -88,7 +88,7 @@ export default function ErrorListDisplay({
     let displayMessage = processErrorMessage(message, isSandboxMode);
     let errorType = "";
 
-    if (message.includes("Missing variable")) {
+    if (message.includes("missing a variable")) {
       errorType = "Missing variable";
     } else if (message.includes("Unexpected variable")) {
       errorType = "Unexpected variable";

--- a/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
+++ b/frontend/src/features/informationTabs/components/ErrorListDisplay.tsx
@@ -72,10 +72,13 @@ export default function ErrorListDisplay({
 
     let processed = message;
 
-    processed = processed.replace(/expected\s+[^,]+,\s+got\s+/gi, "got ");
-    processed = processed.replace(/,?\s*expected\s+[^,]+$/gi, "");
-    processed = processed.replace(/(Missing function):\s*"[^"]+"/gi, "$1");
-    processed = processed.replace(/expected\s+"[^"]+"/gi, "");
+    // Do not trim messages that have "unexpected" in it
+    if (!message.toLowerCase().includes("unexpected")) {
+      processed = processed.replace(/expected\s+[^,]+,\s+got\s+/gi, "got ");
+      processed = processed.replace(/,?\s*expected\s+[^,]+$/gi, "");
+      processed = processed.replace(/(Missing function):\s*"[^"]+"/gi, "$1");
+      processed = processed.replace(/expected\s+"[^"]+"/gi, "");
+    }
 
     return processed.trim();
   };


### PR DESCRIPTION
## Proposed Changes

Fixed two issues with error messages:
1. Some error messages were cut off prematurely for practice mode
2. Unmapped ID messages had paths that were confusing (Trailing "->")

Helps users better recover from errors, especially in practice mode.

Closes #246 

<details>
<summary>Screenshots of your changes (if applicable)</summary>
Issue 1:
Before: error message only says "Un"

After:
<img width="219" height="148" alt="image" src="https://github.com/user-attachments/assets/87c7913a-8ed6-4a59-945d-73b053b7c75b" />

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |    X      |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
    - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
    - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/jcal13/memory-model-editor/blob/dev/frontend/package.json).

After opening your pull request:

- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

Would this PR involve changing / writing tests? Currently I did not do this. Thanks!

For unexpected variable error message, I was thinking of removing "unexpected "variable_name"" from its end to match the expected pattern in errorStructuring.ts's structureError function. I didn't do this yet but I could definitely do this.
<img width="219" height="148" alt="image" src="https://github.com/user-attachments/assets/87c7913a-8ed6-4a59-945d-73b053b7c75b" />
