### PR TITLE
Fixed undo behaviour

### DIFF
--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -13,12 +13,22 @@ import BoxEditor from "../editors/boxEditor/BoxEditor";
 import CallStack from "./components/CallStack";
 import { useCanvasRefs } from "./hooks/useCanvas";
 import { validateElements } from "./utils/validation";
+import { getBoxDimensions } from "./utils/box.renderer";
+import {
+  getCallStackBounds,
+  smoothlyConstrainDragPosition,
+} from "./utils/boundary.helpers";
 import {
   QUESTION_MAIN_FRAME_NAME,
   isLockedMainFrame,
   reorderFunctionFramesWithLockedMain,
 } from "../memoryModelEditor/utils/questionFrames";
 import styles from "./Canvas.module.css";
+
+const NEW_BOX_BOUNDARY_DIMENSIONS = {
+  width: 200,
+  height: 110,
+};
 
 const EDITOR_MAP: Record<BoxType["name"], React.FC<any>> = {
   primitive: BoxEditor,
@@ -192,6 +202,43 @@ function Canvas({
   const { svgRef } = useCanvasRefs();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  const constrainCanvasElementPosition = useCallback(
+    (
+      element: CanvasElement,
+      x: number,
+      y: number,
+      dimensions?: { width: number; height: number },
+    ) => {
+      if (element.kind.name === "function") {
+        return { x, y };
+      }
+
+      const svg = svgRef.current;
+      const vb = svg?.viewBox.baseVal;
+
+      if (!vb || !vb.width || !vb.height) {
+        return { x, y };
+      }
+
+      const elementDimensions = dimensions ?? getBoxDimensions(element);
+
+      const callStackBounds = getCallStackBounds(
+        vb.height,
+        0,
+        0,
+        callStackWidth,
+      );
+
+      return smoothlyConstrainDragPosition(
+        { x, y },
+        elementDimensions,
+        callStackBounds,
+        { width: vb.width, height: vb.height },
+      );
+    },
+    [svgRef, callStackWidth],
+  );
+
   const initialVB =
     typeof window !== "undefined"
       ? `0 0 ${window.innerWidth} ${window.innerHeight}`
@@ -299,20 +346,20 @@ function Canvas({
   // Validate elements whenever they change
   useEffect(() => {
     const validatedElements = validateElements(elements);
-    
+
     // Check if any validation errors have changed
     const hasChanges = validatedElements.some((validatedEl, index) => {
       const currentEl = elements[index];
       if (!currentEl) return true;
-      
+
       const validatedErrors = validatedEl.errors;
       const currentErrors = currentEl.errors;
-      
+
       // Compare errors
       if (!validatedErrors && !currentErrors) return false;
       if (!validatedErrors || !currentErrors) return true;
       if (validatedErrors.length !== currentErrors.length) return true;
-      
+
       return JSON.stringify(validatedErrors) !== JSON.stringify(currentErrors);
     });
 
@@ -324,10 +371,23 @@ function Canvas({
   const createPositionUpdater = useCallback(
     (boxId: number) => (x: number, y: number) => {
       setElements((prev) =>
-        prev.map((el) => (el.boxId === boxId ? { ...el, x, y } : el))
+        prev.map((el) => {
+          if (el.boxId !== boxId) return el;
+
+          const constrained = constrainCanvasElementPosition(el, x, y);
+          if (el.x === constrained.x && el.y === constrained.y) {
+            return el;
+          }
+
+          return {
+            ...el,
+            x: constrained.x,
+            y: constrained.y,
+          };
+        }),
       );
     },
-    [setElements]
+    [setElements, constrainCanvasElementPosition],
   );
 
   const handleCanvasDrop = useCallback(
@@ -354,7 +414,7 @@ function Canvas({
         const newId =
           sandbox || newKind.name === "function" ? "_" : getNextElementId(ids);
 
-        const newElement: CanvasElement = {
+        const baseElement: CanvasElement = {
           boxId: newBoxId,
           id: newId,
           kind: newKind,
@@ -362,10 +422,23 @@ function Canvas({
           y: coords.y,
         };
 
+        const constrained = constrainCanvasElementPosition(
+          baseElement,
+          coords.x,
+          coords.y,
+          NEW_BOX_BOUNDARY_DIMENSIONS,
+        );
+
+        const newElement: CanvasElement = {
+          ...baseElement,
+          x: constrained.x,
+          y: constrained.y,
+        };
+
         return [...prev, newElement];
       });
     },
-    [ids, sandbox, svgRef, setElements]
+    [ids, sandbox, svgRef, setElements, constrainCanvasElementPosition],
   );
 
   const saveElement = useCallback(

--- a/frontend/src/features/canvas/components/CanvasBox.tsx
+++ b/frontend/src/features/canvas/components/CanvasBox.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useCallback } from "react";
+import { useEffect } from "react";
 import { useBoxDragState, useDraggableBox } from "../hooks/useCanvas";
 import { CanvasBoxProps } from "../utils/box.types";
-import {
-  getCallStackBounds,
-  constrainPositionAwayFromCallStack,
-} from "../utils/boundary.helpers";
 
 export default function CanvasBox({
   element,
@@ -38,97 +34,6 @@ export default function CanvasBox({
       onSizeChange(element.boxId as number, { width, height });
     }
   }, [element, onSizeChange, dimensions]);
-
-  // Auto-constraint effect: automatically move boxes away from callstack after render
-  const checkAndConstrainPosition = useCallback(() => {
-    if (disableDrag || !gRef.current) return;
-
-    const { width, height } = dimensions.current;
-    if (width <= 0 || height <= 0) return;
-
-    // Skip constraint for function elements (they belong in the callstack)
-    if (element.kind.name === "function") return;
-
-    const svg = gRef.current.ownerSVGElement;
-    const vb = svg?.viewBox.baseVal;
-    const canvasBounds = vb
-      ? { width: vb.width, height: vb.height }
-      : undefined;
-    const callStackBounds = getCallStackBounds(
-      vb?.height || window.innerHeight,
-      0,
-      0,
-      callStackWidth ?? 225
-    );
-
-    const constrainedPosition = constrainPositionAwayFromCallStack(
-      { x: element.x, y: element.y },
-      { width, height },
-      callStackBounds,
-      canvasBounds
-    );
-
-    // Clamp position to stay within canvas bounds (prevents boxes from being cut off)
-    if (canvasBounds && canvasBounds.width > 0 && canvasBounds.height > 0) {
-      const halfW = width / 2;
-      const halfH = height / 2;
-      constrainedPosition.x = Math.max(
-        halfW,
-        Math.min(canvasBounds.width - halfW, constrainedPosition.x)
-      );
-      constrainedPosition.y = Math.max(
-        halfH,
-        Math.min(canvasBounds.height - halfH, constrainedPosition.y)
-      );
-    }
-
-    // Only update position if it actually changed
-    if (
-      constrainedPosition.x !== element.x ||
-      constrainedPosition.y !== element.y
-    ) {
-      updatePosition(constrainedPosition.x, constrainedPosition.y);
-    }
-  }, [
-    element.x,
-    element.y,
-    element.kind.name,
-    dimensions.current.width,
-    dimensions.current.height,
-    disableDrag,
-    updatePosition,
-    callStackWidth,
-  ]);
-
-  useEffect(() => {
-    checkAndConstrainPosition();
-  }, [checkAndConstrainPosition]);
-
-  // Canvas resize effect: re-constrain position when canvas size changes
-  // Uses ResizeObserver on the parent SVG so it fires for both window resizes
-  // and panel resizes (e.g. dragging the question tab wider)
-  useEffect(() => {
-    if (disableDrag || element.kind.name === "function") return;
-
-    const svg = gRef.current?.ownerSVGElement;
-    if (!svg) return;
-
-    let resizeTimeoutId: NodeJS.Timeout;
-
-    const resizeObserver = new ResizeObserver(() => {
-      clearTimeout(resizeTimeoutId);
-      resizeTimeoutId = setTimeout(() => {
-        checkAndConstrainPosition();
-      }, 100);
-    });
-
-    resizeObserver.observe(svg);
-
-    return () => {
-      resizeObserver.disconnect();
-      clearTimeout(resizeTimeoutId);
-    };
-  }, [checkAndConstrainPosition, disableDrag, element.kind.name]);
 
   return <g ref={gRef} />;
 }

--- a/frontend/src/features/canvas/utils/boundary.helpers.ts
+++ b/frontend/src/features/canvas/utils/boundary.helpers.ts
@@ -126,7 +126,41 @@ export function isElementOverlappingCallStack(
 /**
  * Minimum spacing between elements and the call stack boundary.
  */
-export const CALLSTACK_PADDING = 10;
+export const CALLSTACK_PADDING = 25;
+
+export function getSafeXRightOfCallStack(
+  callStackBounds: CallStackBounds,
+  elementDimensions: ElementDimensions,
+  padding: number = CALLSTACK_PADDING,
+): number {
+  return (
+    callStackBounds.x +
+    callStackBounds.width +
+    padding +
+    elementDimensions.width / 2
+  );
+}
+
+export function clampPositionInsideCanvas(
+  position: Position,
+  elementDimensions: ElementDimensions,
+  canvasBounds: { width: number; height: number },
+  padding: number = CALLSTACK_PADDING,
+): Position {
+  const halfW = elementDimensions.width / 2;
+  const halfH = elementDimensions.height / 2;
+
+  return {
+    x: Math.max(
+      halfW + padding,
+      Math.min(canvasBounds.width - halfW - padding, position.x),
+    ),
+    y: Math.max(
+      halfH + padding,
+      Math.min(canvasBounds.height - halfH - padding, position.y),
+    ),
+  };
+}
 
 /**
  * Adjusts an element's position to avoid overlap with the call stack.
@@ -232,7 +266,20 @@ export function smoothlyConstrainDragPosition(
   // constrain the X position to keep the element's left edge at the boundary
   if (verticalOverlap && elementLeft < callStackRight) {
     // Position the element so its left edge just touches the right edge of the callstack boundary
-    constrainedX = callStackRight + elementHalfWidth;
+    constrainedX = getSafeXRightOfCallStack(callStackBounds, elementDimensions);
+  }
+
+  // Re-apply canvas bounds after call stack correction.
+  // This prevents pushing the box away from the call stack from causing right-side overflow.
+  if (canvasBounds && canvasBounds.width > 0 && canvasBounds.height > 0) {
+    const clamped = clampPositionInsideCanvas(
+      { x: constrainedX, y: constrainedY },
+      elementDimensions,
+      canvasBounds,
+    );
+
+    constrainedX = clamped.x;
+    constrainedY = clamped.y;
   }
 
   return { x: constrainedX, y: constrainedY };

--- a/frontend/src/features/memoryModelEditor/MemoryModelEditor.tsx
+++ b/frontend/src/features/memoryModelEditor/MemoryModelEditor.tsx
@@ -102,8 +102,11 @@ export default function MemoryModelEditor({
     };
 
     // Check if state has actually changed
+    const stripTransient = (els: CanvasElement[]) =>
+      els.map(({ color, ...rest }) => rest);
+    
     const hasChanged =
-      JSON.stringify(prevState.elements) !== JSON.stringify(currentState.elements) ||
+      JSON.stringify(stripTransient(prevState.elements)) !== JSON.stringify(stripTransient(currentState.elements)) ||
       JSON.stringify(prevState.ids) !== JSON.stringify(currentState.ids) ||
       JSON.stringify(prevState.classes) !== JSON.stringify(currentState.classes);
 

--- a/frontend/src/features/memoryModelEditor/MemoryModelEditor.tsx
+++ b/frontend/src/features/memoryModelEditor/MemoryModelEditor.tsx
@@ -130,7 +130,14 @@ export default function MemoryModelEditor({
     state.setActiveInfoTab("question");
     state.setCanvasResetKey((prev) => prev + 1);
     clearCanvasStorage();
-    clearHistory();
+    const baselineState = {
+      elements: [],
+      ids: [],
+      classes: [],
+    };
+    
+    prevStateRef.current = baselineState;
+    clearHistory(baselineState);
   };
 
   const restoreCanvas = (
@@ -138,10 +145,20 @@ export default function MemoryModelEditor({
     ids: number[],
     classes: string[]
   ) => {
-    state.setElements(spreadOverlappingElements(elements));
+    const restoredElements = spreadOverlappingElements(elements);
+
+    const baselineState = {
+      elements: restoredElements,
+      ids,
+      classes,
+    };
+
+    state.setElements(restoredElements);
     state.setElementIds(ids);
     state.setElementClasses(classes);
-    clearHistory();
+
+    prevStateRef.current = baselineState;
+    clearHistory(baselineState);
   };
 
   const effectiveSandboxMode = state.isSandboxMode || state.selectedQuestionType === "experiment";

--- a/frontend/src/features/memoryModelEditor/hooks/useUndoHistory.test.ts
+++ b/frontend/src/features/memoryModelEditor/hooks/useUndoHistory.test.ts
@@ -1,0 +1,118 @@
+import { renderHook, act } from "@testing-library/react";
+import { useState } from "react";
+import { useUndoHistory } from "./useUndoHistory";
+
+describe("useUndoHistory", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const renderUndoHistory = () =>
+    renderHook(() => {
+      const [elements, setElements] = useState<any[]>([]);
+      const [ids, setIds] = useState<number[]>([]);
+      const [classes, setClasses] = useState<string[]>([]);
+
+      const undoHistory = useUndoHistory(setElements, setIds, setClasses);
+
+      return { elements, ids, classes, ...undoHistory };
+    });
+
+  it("undoes newly added boxes one by one", () => {
+    const { result } = renderUndoHistory();
+
+    act(() => {
+      result.current.clearHistory({ elements: [], ids: [], classes: [] });
+    });
+
+    act(() => {
+      result.current.recordState({
+        elements: [{ boxId: 1, id: "id1", kind: { name: "int" }, x: 0, y: 0 }],
+        ids: [1],
+        classes: [],
+      } as any);
+    });
+
+    act(() => {
+      result.current.recordState({
+        elements: [
+          { boxId: 1, id: "id1", kind: { name: "int", value: 0 }, x: 0, y: 0 },
+          { boxId: 2, id: "id2", kind: { name: "int", value: 0 }, x: 100, y: 0 },
+        ],
+        ids: [1, 2],
+        classes: [],
+      } as any);
+    });
+
+    act(() => {
+      result.current.recordState({
+        elements: [
+          { boxId: 1, id: "id1", kind: { name: "int", value: 0 }, x: 0, y: 0 },
+          { boxId: 2, id: "id2", kind: { name: "int", value: 0 }, x: 10, y: 0 },
+          { boxId: 3, id: "id3", kind: { name: "int", value: 0 }, x: 20, y: 0 },
+        ],
+        ids: [1, 2, 3],
+        classes: [],
+      } as any);
+    });
+
+    act(() => result.current.undo());
+    expect(result.current.elements.map((el) => el.boxId)).toEqual([1, 2]);
+
+    act(() => result.current.undo());
+    expect(result.current.elements.map((el) => el.boxId)).toEqual([1]);
+
+    act(() => result.current.undo());
+    expect(result.current.elements).toEqual([]);
+  });
+
+  it("undoes value edits before undoing added boxes", () => {
+    const { result } = renderUndoHistory();
+
+    act(() => {
+      result.current.clearHistory({ elements: [], ids: [], classes: [] });
+    });
+
+    act(() => {
+      result.current.recordState({
+        elements: [
+          { boxId: 1, id: "id1", kind: { name: "int", value: 0 }, x: 0, y: 0 },
+        ],
+        ids: [1],
+        classes: [],
+      } as any);
+    });
+
+    act(() => {
+      result.current.recordState({
+        elements: [
+          { boxId: 1, id: "id1", kind: { name: "int", value: 0 }, x: 0, y: 0 },
+          { boxId: 2, id: "id2", kind: { name: "int", value: 0 }, x: 10, y: 0 },
+        ],
+        ids: [1, 2],
+        classes: [],
+      } as any);
+    });
+
+    act(() => {
+      result.current.recordState({
+        elements: [
+          { boxId: 1, id: "id1", kind: { name: "int", value: 1 }, x: 0, y: 0 },
+          { boxId: 2, id: "id2", kind: { name: "int", value: 0 }, x: 10, y: 0 },
+        ],
+        ids: [1, 2],
+        classes: [],
+      } as any);
+    });
+
+    act(() => result.current.undo());
+    expect(result.current.elements[0].kind.value).toBe(0);
+    expect(result.current.elements.map((el) => el.boxId)).toEqual([1, 2]);
+
+    act(() => result.current.undo());
+    expect(result.current.elements.map((el) => el.boxId)).toEqual([1]);
+
+    act(() => result.current.undo());
+    expect(result.current.elements).toEqual([]);
+  });
+});

--- a/frontend/src/features/memoryModelEditor/hooks/useUndoHistory.ts
+++ b/frontend/src/features/memoryModelEditor/hooks/useUndoHistory.ts
@@ -13,12 +13,15 @@ interface UndoHistoryReturn {
   undo: () => void;
   redo: () => void;
   recordState: (state: CanvasState) => void;
-  clearHistory: () => void;
+  clearHistory: (baselineState?: CanvasState) => void;
 }
 
 const MAX_HISTORY_SIZE = 50;
 const HISTORY_STORAGE_KEY = "canvas_undo_history";
 const HISTORY_INDEX_STORAGE_KEY = "canvas_undo_history_index";
+
+const normalizeElements = (elements: CanvasElement[]) =>
+  elements.map(({ color, invalidated, ...rest }) => rest);
 
 export function useUndoHistory(
   setElements: React.Dispatch<React.SetStateAction<CanvasElement[]>>,
@@ -59,39 +62,49 @@ export function useUndoHistory(
   const recordState = useCallback((state: CanvasState) => {
     // Don't record while we're undoing/redoing to prevent recursion
     if (isUndoRedoing.current) return;
-
+    
     setHistory((prev) => {
       // If we're in the middle of history (after undo), discard future states
       const currentHistory = prev.slice(0, historyIndex + 1);
-
+    
       // Deep clone the state to prevent mutations
       const clonedState: CanvasState = {
         elements: JSON.parse(JSON.stringify(state.elements)),
         ids: [...state.ids],
         classes: [...state.classes],
       };
-
+    
       // Add new state
+      const lastState = currentHistory[currentHistory.length - 1];
+    
+      const isDuplicate =
+        lastState &&
+        JSON.stringify(normalizeElements(lastState.elements)) ===
+          JSON.stringify(normalizeElements(clonedState.elements));
+    
+      if (isDuplicate) {
+        return prev;
+      }
+    
       const updatedHistory = [...currentHistory, clonedState];
-
+    
       // Limit history size
       if (updatedHistory.length > MAX_HISTORY_SIZE) {
         const trimmed = updatedHistory.slice(1);
         // Adjust index since we removed from the beginning
-        setHistoryIndex((prev) => Math.max(-1, prev - 1));
+        setHistoryIndex(trimmed.length - 1);
         return trimmed;
       }
-
+    
+      setHistoryIndex(updatedHistory.length - 1);
       return updatedHistory;
     });
-
-    setHistoryIndex((prev) => prev + 1);
   }, [historyIndex]);
 
   const undo = useCallback(() => {
     // Need at least 2 states in history to undo (index 1 to go back to index 0)
     if (historyIndex < 1) return;
-
+    
     isUndoRedoing.current = true;
 
     const previousIndex = historyIndex - 1;
@@ -138,12 +151,19 @@ export function useUndoHistory(
     }, 0);
   }, [history, historyIndex, setElements, setElementIds, setElementClasses]);
 
-  const clearHistory = useCallback(() => {
-    setHistory([]);
-    setHistoryIndex(-1);
+  const clearHistory = useCallback((baselineState?: CanvasState) => {
+    const initialState: CanvasState = baselineState ?? {
+      elements: [],
+      ids: [],
+      classes: [],
+    };
+  
+    setHistory([initialState]);
+    setHistoryIndex(0);
+  
     try {
-      localStorage.removeItem(HISTORY_STORAGE_KEY);
-      localStorage.removeItem(HISTORY_INDEX_STORAGE_KEY);
+      localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify([initialState]));
+      localStorage.setItem(HISTORY_INDEX_STORAGE_KEY, "0");
     } catch (error) {
       console.error("Failed to clear undo history from localStorage:", error);
     }


### PR DESCRIPTION
## Proposed Changes

Fixes undo history initialization for restored and cleared canvases.

Previously, after refreshing or restoring a canvas, the first newly added box could not be undone correctly. This change resets undo history using the current canvas state as the baseline, ensuring newly added boxes are tracked immediately after loading or refreshing the editor.

Also improves duplicate undo-state filtering by normalizing element comparisons before recording history snapshots.

Fixed #296 & #305
...

<details>
<summary>Screenshots of your changes (if applicable)</summary>
(Adding 3 boxes, exactly one box is removed when undo is clicked until the empty canvas where the undo button is greyed out.)
<img width="1920" height="992" alt="Screenshot 2026-05-25 at 3 15 36 PM" src="https://github.com/user-attachments/assets/e237ff4b-6408-4e9c-b1cb-32405478e5bc" />
<img width="1920" height="992" alt="Screenshot 2026-05-25 at 3 15 42 PM" src="https://github.com/user-attachments/assets/d9d53915-8323-4fcb-b333-ce11f10a238e" />
<img width="1920" height="992" alt="Screenshot 2026-05-25 at 3 15 49 PM" src="https://github.com/user-attachments/assets/4916f027-a3c0-4488-b313-c4961484c7d7" />
<img width="1920" height="992" alt="Screenshot 2026-05-25 at 3 15 58 PM" src="https://github.com/user-attachments/assets/5c6712d4-6f75-47b8-996f-d2319b875ba7" />

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  | X         |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          | X         |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
    - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
    - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/jcal13/memory-model-editor/blob/dev/frontend/package.json).

After opening your pull request:

- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

There are still some edge cases such as overlapping boxes that can create visually duplicated undo states.